### PR TITLE
Persistent layer and integration with enclave's service bus (based on NATS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,7 @@ dependencies = [
  "axum-extra",
  "axum-macros",
  "axum-server",
+ "bytes",
  "futures",
  "hex",
  "openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 name = "ra-web-srv"
 version = "0.7.1"
 dependencies = [
+ "async-nats",
  "async-std",
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",

--- a/fs-monitor/Cargo.toml
+++ b/fs-monitor/Cargo.toml
@@ -5,18 +5,16 @@ edition = "2021"
 
 [dependencies]
 inotify = "0.11.0"
-futures = "0.3.30"
+futures = "0.3"
 notify = "7.0.0"
 sha2 = "0.10.0"
 dashmap = "6.1.0"
 glob = "0.3.2"
 tempfile = "3.17.1"
 sha3 = "0.10.8"
-# tokio = { version = "1.36.0", features = ["full"] }
 tokio = { version = "1.44", features = ["full"] }
 clap = { version = "4.5.28", features = ["derive"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 notify-debouncer-full = "0.5.0"
-# async-nats = "0.36.0"
 async-nats = "0.42"
 bytes = "1.10.1"

--- a/ra-web-srv/Cargo.toml
+++ b/ra-web-srv/Cargo.toml
@@ -36,3 +36,4 @@ parking_lot = "0.12"
 openssl = { version = "0.10", features = ["vendored"] }
 vrf = { git = "https://github.com/andrcmdr/vrf-rs.git", branch = "main", version = "0.3.0" }
 # vrf = { path = "../../vrf", version = "0.3.0" }
+async-nats = "0.42"

--- a/ra-web-srv/Cargo.toml
+++ b/ra-web-srv/Cargo.toml
@@ -37,3 +37,4 @@ openssl = { version = "0.10", features = ["vendored"] }
 vrf = { git = "https://github.com/andrcmdr/vrf-rs.git", branch = "main", version = "0.3.0" }
 # vrf = { path = "../../vrf", version = "0.3.0" }
 async-nats = "0.42"
+bytes = "1.10"


### PR DESCRIPTION
**[ra-web-srv] Persistent layer and integration with enclave's service bus (based on NATS).**

Integrate persistent storage (NATS KV bucket) into `make_attestation_docs` function, respecting application configuration. Made generation of attestation documents from Walker and Watcher tasks, modified Producer task for generating of attestation docs. Made clean chain of responsibility through NATS Orchestrator task. Respect application configuration.
